### PR TITLE
updated Custom Prompt Dialog

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -304,8 +304,8 @@
     <div class="layout-body">
       <div>
         <p class="text-center mb-2">Select a theme: </p>
-          <select id="selectVerilogTheme" class="applyTheme" style="width:90%;">    
-            <optgroup label="Light Themes">     
+          <select id="selectVerilogTheme" class="applyTheme" style="width:90%;">
+            <optgroup label="Light Themes">
               <option>default</option>
               <option>solarized</option>
               <option>elegant</option>
@@ -641,6 +641,15 @@
     <label >Octal value</label><br><input  type='text' id='octalInput' value='020' label="Octal" name='text1'><br><br>
     <label >Hexadecimal value</label><br><input  type='text' id='hexInput' value='0x10' label="Hex" name='text1'><br><br>
 </div>
+
+<!----- prompt model ----------->
+<div id="promptDialog"
+  class='promptDialogBox'
+  tabindex = "0"
+  style="display: none;"
+  title="Message"></div>
+
+
 <!---issue reporting-system----->
 <div class="report-sidebar">
   <a

--- a/simulator/src/circuit.js
+++ b/simulator/src/circuit.js
@@ -34,6 +34,7 @@ import { changeClockEnable } from './sequential';
 import { changeInputSize } from './modules';
 import { verilogModeGet, verilogModeSet } from './Verilog2CV';
 import { updateTestbenchUI } from './testbench';
+import { promptDialog } from './dialog/promptDialog';
 
 export const circuitProperty = {
     toggleLayoutMode, setProjectName, changeCircuitName, changeClockTime, deleteCurrentCircuit, changeClockEnable, changeInputSize, changeLightMode,
@@ -132,12 +133,32 @@ function deleteCurrentCircuit(scopeId = globalScope.id) {
  * Wrapper function around newCircuit to be called from + button on UI
  */
 export function createNewCircuitScope() {
-    const scope = newCircuit();
-    if (!embed) {
-        showProperties(simulationArea.lastSelected);
-        updateTestbenchUI();
-        plotArea.reset();
-    }
+    promptDialog('Enter circuit name:', 'Untitled-Circuit');
+    $('#promptDialog').dialog({
+        buttons: [
+            {
+                text: 'cancel',
+                click() {
+                    // to close the dialog
+                    $('#promptDialog').dialog('close');
+                },
+            },
+            {
+                text: 'confirm',
+                click() {
+                    const name = stripTags($('#promptInput').val());
+                    const scope = newCircuit(name);
+                    if (!embed) {
+                        showProperties(simulationArea.lastSelected);
+                        updateTestbenchUI();
+                        plotArea.reset();
+                    }
+                    // to close the dialog
+                    $('#promptDialog').dialog('close');
+                },
+            },
+        ],
+    });
 }
 
 /**
@@ -150,8 +171,6 @@ export function createNewCircuitScope() {
 export function newCircuit(name, id, isVerilog = false, isVerilogMain = false) {
     if (layoutModeGet()) { toggleLayoutMode(); }
     if (verilogModeGet()) { verilogModeSet(false);}
-    name = name || prompt('Enter circuit name:','Untitled-Circuit');
-    name = stripTags(name);
     if (!name) return;
     const scope = new Scope(name);
     if (id) scope.id = id;
@@ -189,7 +208,7 @@ export function newCircuit(name, id, isVerilog = false, isVerilogMain = false) {
                 document.getElementById('circname').select();
             }, 100);
         });
-        
+
         $('.tabsCloseButton').on('click',function (e) {
             e.stopPropagation();
             deleteCurrentCircuit(this.id);
@@ -199,7 +218,7 @@ export function newCircuit(name, id, isVerilog = false, isVerilogMain = false) {
         }
         dots(false);
     }
-    
+
     return scope;
 }
 
@@ -247,7 +266,7 @@ export default class Scope {
         this.oy = 0;
         this.scale = DPR;
         this.stack = [];
-        
+
         this.initialize();
 
         // Setting default layout

--- a/simulator/src/css/main.stylesheet.css
+++ b/simulator/src/css/main.stylesheet.css
@@ -1801,6 +1801,24 @@ input[type='range']::-webkit-slider-thumb {
 
   /*! Custom Color theme dialog styles ends here*/
 
+  .ui-dialog[aria-describedby="promptDialog"] {
+    min-width: 500px;
+    user-select: none;
+}
+.promptDialogBox{
+    color: white;
+}
+.promptDialogBox input{
+    background: none;
+    color: white !important;
+    border: 1px solid black;
+    width: 90%;
+    height: 25px;
+    padding: 4px;
+    color: white;
+    outline: none;
+    margin: 5px auto;
+}
 
 
 

--- a/simulator/src/data.js
+++ b/simulator/src/data.js
@@ -4,7 +4,7 @@ import save from './data/save';
 import load from './data/load';
 import createSaveAsImgPrompt from './data/saveImage'
 import { clearProject, newProject, saveOffline, openOffline, recoverProject } from './data/project'
-import { newCircuit, createNewCircuitScope } from './circuit'
+import { createNewCircuitScope } from './circuit'
 import { createCombinationalAnalysisPrompt } from './combinationalAnalysis';
 import { colorThemes } from "./themer/themer";
 import { showTourGuide } from './tutorials';
@@ -19,7 +19,7 @@ logixFunction.createSaveAsImgPrompt = createSaveAsImgPrompt;
 logixFunction.clearProject = clearProject;
 logixFunction.newProject = newProject;
 logixFunction.saveOffline = saveOffline;
-logixFunction.newCircuit = newCircuit;
+logixFunction.newCircuit = createNewCircuitScope;
 logixFunction.createOpenLocalPrompt = openOffline;
 logixFunction.recoverProject = recoverProject;
 logixFunction.createSubCircuitPrompt = createSubCircuitPrompt;

--- a/simulator/src/data/save.js
+++ b/simulator/src/data/save.js
@@ -349,7 +349,7 @@ export default async function save() {
                     const name = stripTags($('#promptInput').val());
                     if (name) {
                         setProjectName(name);
-                        setTimeout(save, 1000);
+                        save();
                     }
                     // to close the dialog
                     $('#promptDialog').dialog('close');

--- a/simulator/src/dialog/promptDialog.js
+++ b/simulator/src/dialog/promptDialog.js
@@ -1,0 +1,19 @@
+function getDialogContent(label, defaultValue) {
+    return `
+        <label for='promptInput'>${label}</label>
+        <input id='promptInput' type='text' placeholder='${defaultValue}' name='promptInput'>
+    `;
+}
+
+/**
+ * A function to prompt Message on Simulator
+ * Replacement for js-prompt dialogs
+ * @param {String} message
+ */
+export const promptDialog = (label, defaultValue) => {
+    $("#promptDialog").empty();
+    $("#promptDialog").append(getDialogContent(label, defaultValue));
+    $("#promptDialog").dialog({
+        resizable: false,
+    });
+};


### PR DESCRIPTION
Fixes #41 

### [GSOC'22 Task Assignment](https://github.com/CircuitVerse/CircuitVerse/wiki/GSoC-2022-Task-assignments#simulator-improvements)

Relace js `prompt` with custom Prompt dialog

## This can be done in two Major Steps:
1. Call the prompt dialog function and pass two arguments (label and default value).
2. Add event Listeners to buttons and click on the Ok button, which returns the callback function.


### Screenshots of the changes (If any) -

#### Save Online
https://user-images.githubusercontent.com/76155456/161962536-242cc6c1-c7f4-4bdd-8de7-90c788453c43.mov

#### New Circuit
https://user-images.githubusercontent.com/76155456/161971877-765ac5a5-3c19-493b-a7b0-9dd18603ba9d.mov

## Work Flow
![Pulkit Gupta GSOC'22 Proposal CircuitVerse (2)](https://user-images.githubusercontent.com/76155456/163724415-a0083a15-87c5-4429-a3a3-ccef73fc61b5.jpg)
